### PR TITLE
chart: remove duplicate labels and fix selectors

### DIFF
--- a/charts/brigade-noisy-neighbor/templates/deployment.yaml
+++ b/charts/brigade-noisy-neighbor/templates/deployment.yaml
@@ -4,18 +4,15 @@ metadata:
   name: {{ include "brigade-noisy-neighbor.fullname" . }}
   labels:
     {{- include "brigade-noisy-neighbor.labels" . | nindent 4 }}
-    {{- include "brigade-noisy-neighbor.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       {{- include "brigade-noisy-neighbor.selectorLabels" . | nindent 6 }}
-      {{- include "brigade-noisy-neighbor.labels" . | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "brigade-noisy-neighbor.selectorLabels" . | nindent 8 }}
-        {{- include "brigade-noisy-neighbor.labels" . | nindent 8 }}
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:

--- a/charts/brigade-noisy-neighbor/templates/secret.yaml
+++ b/charts/brigade-noisy-neighbor/templates/secret.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ include "brigade-noisy-neighbor.fullname" . }}
   labels:
     {{- include "brigade-noisy-neighbor.labels" . | nindent 4 }}
-    {{- include "brigade-noisy-neighbor.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   api-token: {{ .Values.brigade.apiToken }}


### PR DESCRIPTION
Critically important in this PR: selectors on deployments and services previously included version information and they're really not supposed to. Selectors are immutable, so this mistake is preventing upgrades.