### PR TITLE
fix go.mod and use go 1.17 features to improve tests

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -2,7 +2,7 @@ import { events, Event, Job, ConcurrentGroup, SerialGroup } from "@brigadecore/b
 
 const releaseTagRegex = /^refs\/tags\/(v[0-9]+(?:\.[0-9]+)*(?:\-.+)?)$/
 
-const goImg = "brigadecore/go-tools:v0.1.0"
+const goImg = "brigadecore/go-tools:v0.3.0"
 const kanikoImg = "brigadecore/kaniko:v0.2.0"
 const helmImg = "brigadecore/helm-tools:v0.2.0"
 const localPath = "/workspaces/brigade-noisy-neighbor"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM brigadecore/go-tools:v0.1.0
+FROM brigadecore/go-tools:v0.3.0
 
 ARG VERSION
 ARG COMMIT

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty --match=NeVeRmAtC
 
 ifneq ($(SKIP_DOCKER),true)
 	PROJECT_ROOT := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-	GO_DEV_IMAGE := brigadecore/go-tools:v0.1.0
+	GO_DEV_IMAGE := brigadecore/go-tools:v0.3.0
 
 	GO_DOCKER_CMD := docker run \
 		-it \

--- a/config_test.go
+++ b/config_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os"
 	"testing"
 
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
@@ -41,7 +40,7 @@ func TestAPIClientConfig(t *testing.T) {
 		{
 			name: "API_TOKEN not set",
 			setup: func() {
-				os.Setenv("API_ADDRESS", "foo")
+				t.Setenv("API_ADDRESS", "foo")
 			},
 			assertions: func(
 				_ string,
@@ -57,8 +56,8 @@ func TestAPIClientConfig(t *testing.T) {
 		{
 			name: "success",
 			setup: func() {
-				os.Setenv("API_TOKEN", "bar")
-				os.Setenv("API_IGNORE_CERT_WARNINGS", "true")
+				t.Setenv("API_TOKEN", "bar")
+				t.Setenv("API_IGNORE_CERT_WARNINGS", "true")
 			},
 			assertions: func(
 				address string,

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/brigadecore/brigade-noisy-neighbor
 go 1.16
 
 require (
+	github.com/brigadecore/brigade-foundations v0.3.0
 	github.com/brigadecore/brigade/sdk/v2 v2.0.0-beta.1
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/brigadecore/brigade-foundations v0.3.0 h1:galsMzxSprURAEc2pxsmYJandiW4D+Npchx6ZiBIHkY=
+github.com/brigadecore/brigade-foundations v0.3.0/go.mod h1:edMgSJCUgfHN1RNGiiVOTRW4X4VykBLgssgWHPZK7Sg=
 github.com/brigadecore/brigade/sdk/v2 v2.0.0-beta.1 h1:diVZz6uGMAS2eImx39A15ZRP2eoitiC4TbhcgNVUwIg=
 github.com/brigadecore/brigade/sdk/v2 v2.0.0-beta.1/go.mod h1:rB3y/pIheORX5AHbxaSAw5Xr/U6bUAUtSLkgJcbOHIY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
Signed-off-by: Kent Rancourt <kent.rancourt@microsoft.com>