### PR TITLE
docker login for all image builds in ci

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -60,6 +60,10 @@ class MakeTargetJob extends Job {
 // builders, we can streamline all of this pretty significantly.
 class BuildImageJob extends MakeTargetJob {
   constructor(target: string, event: Event, env?: {[key: string]: string}) {
+    env ||= {}
+    env["DOCKER_ORG"] = event.project.secrets.dockerhubOrg
+    env["DOCKER_USERNAME"] = event.project.secrets.dockerhubUsername
+    env["DOCKER_PASSWORD"] = event.project.secrets.dockerhubPassword
     super([target], dockerClientImg, event, env)
     this.primaryContainer.environment.DOCKER_HOST = "localhost:2375"
     this.primaryContainer.command = [ "sh" ]
@@ -79,11 +83,7 @@ class BuildImageJob extends MakeTargetJob {
 // PushImageJob is a specialized job type for publishing Docker images.
 class PushImageJob extends BuildImageJob {
   constructor(target: string, event: Event, version?: string) {
-    const env = {
-      "DOCKER_ORG": event.project.secrets.dockerhubOrg,
-      "DOCKER_USERNAME": event.project.secrets.dockerhubUsername,
-      "DOCKER_PASSWORD": event.project.secrets.dockerhubPassword
-    }
+    const env = {}
     if (version) {
       env["VERSION"] = version
     }

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ upload-code-coverage:
 
 .PHONY: build
 build:
+	docker login $(DOCKER_REGISTRY) -u $(DOCKER_USERNAME) -p $${DOCKER_PASSWORD}
 	docker buildx build \
 		-t $(DOCKER_IMAGE_NAME):$(IMMUTABLE_DOCKER_TAG) \
 		-t $(DOCKER_IMAGE_NAME):$(MUTABLE_DOCKER_TAG) \


### PR DESCRIPTION
This is a step toward addressing DockerHub rate limiting. Our most frequent pulls are due to the `FROM` directive in Dockerfiles that we build in our jobs, so logging in before image builds, the way we already do before image pushes is one of the best measures we can take against bumping into the rate limit.

We may still need to do more, but this should be a significant improvement.