### PR TITLE
doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,104 +7,19 @@
 
 <img width="100" align="left" src="logo.png">
 
-This is a work-in-progress component that emits events (noise) into a Brigade 2
+The Brigade Noisy Neighbor component emits events (noise) into a Brigade 2
 installation's event bus at a configurable frequency. This is useful for
 applying load to a Brigade 2 installation for testing purposes or to gain
 operational insight.
 
 <br clear="left"/>
 
-## Getting Started
-
-Follow these steps to get started.
-
-### Prerequisites
-
-An operational Brigade 2 installation is a prerequisite.
-
-If necessary, please refer to
-[Brigade 2's own getting started documentation](https://github.com/brigadecore/brigade/tree/v2)
-for guidance in fulfilling this dependency.
-
-Once Brigade 2 is operational, create a service account for use by Brigade
-Noisy Neighbor:
-
-```console
-$ brig service-account create \
-    --id brigade-noisy-neighbor \
-    --description "Used by Brigade Noisy Neighbor"
-```
-
-This command will display a token that Brigade Noisy Neighbor can use for
-authenticating to the Brigade 2 API server. Take note of this value. It will be
-required in subsequent steps and cannot be retrieved later through any other
-means.
-
-Now grant the service account permission to create events from the
-`brigade.sh/noisy-neighbor` source:
-
-```console
-$ brig role grant EVENT_CREATOR
-    --service-account brigade-noisy-neighbor \
-    --source brigade.sh/noisy-neighbor
-```
-
-### Installing Brigade Noisy Neighbor
-
-For now, we're using the [GitHub Container Registry](https://ghcr.io) (which is
-an [OCI registry](https://helm.sh/docs/topics/registries/)) to host our Helm
-chart. Helm 3.7 has _experimental_ support for OCI registries. In the event that
-the Helm 3.7 dependency proves troublesome for users, or in the event that this
-experimental feature goes away, or isn't working like we'd hope, we will revisit
-this choice before going GA.
-
-First, be sure you are using
-[Helm 3.7.0](https://github.com/helm/helm/releases/tag/v3.7.0) or greater and
-enable experimental OCI support:
-
-```console
-$ export HELM_EXPERIMENTAL_OCI=1
-```
-
-Use the following command to extract the full set of configuration options from
-the chart. Here we're storing a copy at `~/brigade-noisy-neighbor-values.yaml`:
-
-```console
-$ helm inspect values oci://ghcr.io/brigadecore/brigade-noisy-neighbor \
-    --version v0.4.1 > ~/brigade-noisy-neighbor-values.yaml
-```
-
-Edit the configuration (`~/brigade-noisy-neighbor-values.yaml` in this example).
-At minimum, you will need to make the following changes:
-
-* Set the value of `brigade.apiAddress` to the address of your Brigade 2 API
-  server. This should utilize the _internal_ DNS hostname by which that API
-  server is reachable _within_ your Kubernetes cluster. This value is defaulted
-  to `https://brigade-apiserver.brigade.svc.cluster.local`, but may need to be
-  updated if you installed Brigade 2 in a different namespace.
-
-* Set the value of `brigade.apiToken` to the service account token that was
-  generated earlier.
-
-Install Brigade Noisy Neighbor, referencing your edited configuration:
-
-```console
-$ helm install brigade-noisy-neighbor \
-    oci://ghcr.io/brigadecore/brigade-noisy-neighbor \
-    --version v0.4.1 \
-    --create-namespace \
-    --namespace brigade-noisy-neighbor \
-    --values ~/brigade-noisy-neighbor-values.yaml \
-    --wait
-```
-
-### Subscribing to Noise Events
-
-The Brigade Noisy Neighbor should almost immediately begin emitting events into
-your Brigade 2 installation's event bus. This will have no real effect, however,
-unless any projects are subscribed to those events.
-
-Here is an example project definition that subscribes to such events:
+After [installation](docs/INSTALLATION.md), subscribe any number of Brigade
+[projects](https://docs.brigade.sh/topics/project-developers/projects/)
+to events emitted by this component -- all of which have a value of
+`brigade.sh/noisy-neighbor` in their `source` field and a value of `noise` in
+their `type` field. In the example project definition below, we subscribe to all
+all such events:
 
 ```yaml
 apiVersion: brigade.sh/v2
@@ -133,15 +48,32 @@ spec:
 
 ```
 
-Besides subscribing to noise events, this project definition also embeds a
-`brigade.js` script that will handle such events with a single job that sleeps
-for five seconds.
+Assuming this file were named `project.yaml`, you can create the project like
+so:
 
-Submit this project to Brigade:
+```shell
+$ brig project create --file project.yaml
+```
 
+> ⚠️&nbsp;&nbsp;Projects always receive discrete copies of each event they are
+> subscribed to, so be mindful that no matter the frequency on which the Noisy
+> Neighbor is configured to emit events, the total volume of events will also be
+> dependent on the number of subscribers. If this component emits an event once
+> every five seconds, but two projects subscribe to them, you'll effectively be
+> receiving _two_ events every five seconds.
+
+After allowing sufficient time to pass for new events to have been emitted by
+the Noisy Neighbor, list the events for the `noisy-ned` project to confirm you
+have subscribed correctly:
+
+```shell
+$ brig event list --project noisy-ned
 ```
-$ brig project create -f path/to/noisy-ned.yaml
-```
+
+Full coverage of `brig` commands is beyond the scope of this documentation, but
+at this point,
+[additional `brig` commands](https://docs.brigade.sh/topics/project-developers/brig/)
+can be applied to monitor and managed the events.
 
 ## Contributing
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,88 @@
+# Installation
+
+## Prerequisites
+
+* A Kubernetes cluster:
+  * For which you have the `admin` cluster role.
+  * That is already running Brigade v2.0.0 or greater.
+* `helm`: Commands below require `helm` 3.7.0+.
+* `brig`: The Brigade CLI. Commands below require `brig` 2.0.0+.
+
+## Create a Service Account for the Noisy Neighbor
+
+> ⚠️&nbsp;&nbsp;To proceed beyond this point, you'll need to be logged into
+> Brigade as the "root" user (not recommended) or (preferably) as a user with
+> the `ADMIN` role. Further discussion of this is beyond the scope of this
+> documentation. Please refer to Brigade's own documentation.
+
+1. Using the `brig` CLI, create a service account for the Noisy Neighbor to use:
+
+   ```shell
+   $ brig service-account create \
+       --id brigade-noisy-neighbor \
+       --description "Used by Brigade Noisy Neighbor"
+   ```
+
+1. Make note of the __token__ returned. This value will be used in another step.
+
+   > ⚠️&nbsp;&nbsp;This is your only opportunity to access this value, as
+   > Brigade does not save it.
+
+1. Authorize this service account to create events:
+
+   ```shell
+   $ brig role grant EVENT_CREATOR
+       --service-account brigade-noisy-neighbor \
+       --source brigade.sh/noisy-neighbor
+   ```
+
+   > ⚠️&nbsp;&nbsp;The `--source brigade.sh/noisy-neighbor` option specifies
+   > that this service account can be used _only_ to create events having a
+   > value of `brigade.sh/noisy-neighbor` in the event's `source` field. This is
+   > a security measure that prevents this component from using this token for
+   > impersonating other event sources.
+
+## Install the Noisy Neighbor
+
+> ⚠️&nbsp;&nbsp;be sure you are using
+> [Helm 3.7.0](https://github.com/helm/helm/releases/tag/v3.7.0) or greater and
+> enable experimental OCI support:
+>
+> ```shell
+>  $ export HELM_EXPERIMENTAL_OCI=1
+>  ```
+
+1. As this component requires some specific configuration to function properly,
+   we'll first create a values file containing those settings. Use the following
+   command to extract the full set of configuration options into a file you can
+   modify:
+
+   ```shell
+   $ helm inspect values oci://ghcr.io/brigadecore/brigade-noisy-neighbor \
+       --version v0.4.1 > ~/brigade-noisy-neighbor-values.yaml
+   ```
+
+1. Edit `~/brigade-noisy-neighbor-values.yaml`, making the following changes:
+
+   * `brigade.apiAddress`: Set this to the address of the Brigade API server,
+     beginning with `https://`.
+
+   * `brigade.apiToken`: Set this to the service account token obtained when you
+     created the Brigade service account for this component.
+
+   * `noiseFrequency`: Optionally edit this to control the frequency with which
+     noise events are emitted into Brigade's event bus.
+
+1. Save your changes to `~/brigade-noisy-neighbor-values.yaml`.
+
+1. Use the following command to install the Noisy Neighbor:
+
+   ```shell
+   $ helm install brigade-noisy-neighbor \
+       oci://ghcr.io/brigadecore/brigade-noisy-neighbor \
+       --version v0.4.1 \
+       --create-namespace \
+       --namespace brigade-noisy-neighbor \
+       --values ~/brigade-noisy-neighbor-values.yaml \
+       --wait
+   ```


### PR DESCRIPTION
This is a big doc update that puts the README's focus on what the component _does_ and moves installation instructions to a separate page. It's modeled after the GitHub gateway, which I think has the most mature docs of any of our peripherals.

After this, I'll cut an RC and PR some pre-release version bumps.

There's not much to this component, so it's overdue for going GA.